### PR TITLE
Replaced mysql connector with working version.

### DIFF
--- a/kubernetes/Dockerfile.mysql
+++ b/kubernetes/Dockerfile.mysql
@@ -3,5 +3,4 @@ FROM docker.bintray.io/jfrog/artifactory-pro:5.2.1
 MAINTAINER eldada@jfrog.com
 
 # Download the DB driver into Tomcat's lib
-RUN curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.2.10.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar
-
+RUN curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.1.41.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar

--- a/kubernetes/Dockerfile.mysql
+++ b/kubernetes/Dockerfile.mysql
@@ -3,5 +3,5 @@ FROM docker.bintray.io/jfrog/artifactory-pro:5.2.1
 MAINTAINER eldada@jfrog.com
 
 # Download the DB driver into Tomcat's lib
-RUN curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.2.10.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.2.10/mysql-connector-java-5.2.10.jar
+RUN curl -L -o /opt/jfrog/artifactory/tomcat/lib/mysql-connector-java-5.2.10.jar https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar
 


### PR DESCRIPTION
kubernetes/Dockerfile.mysql references the file https://jcenter.bintray.com/mysql/mysql-connector-java/5.2.10/mysql-connector-java-5.2.10.jar, which does not exist and returns a 404. I've replaced it with https://jcenter.bintray.com/mysql/mysql-connector-java/5.1.41/mysql-connector-java-5.1.41.jar so that containers can now successfully access to mysql databases.