### PR TITLE
Issue #26: Ulimit sometimes required to start service using compose

### DIFF
--- a/docker-compose/artifactory-ha-shared-data.yml
+++ b/docker-compose/artifactory-ha-shared-data.yml
@@ -16,7 +16,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   artifactory-node1:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
@@ -46,7 +46,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   artifactory-node2:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
@@ -79,7 +79,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
@@ -102,5 +102,5 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000

--- a/docker-compose/artifactory-ha-shared-data.yml
+++ b/docker-compose/artifactory-ha-shared-data.yml
@@ -13,6 +13,10 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   artifactory-node1:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node1
@@ -38,6 +42,10 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   artifactory-node2:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node2
@@ -66,6 +74,10 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -84,3 +96,7 @@ services:
      - ART_BASE_URL=http://artifactory-node1:8081/artifactory
      - SSL=true
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000

--- a/docker-compose/artifactory-ha-shared-data.yml
+++ b/docker-compose/artifactory-ha-shared-data.yml
@@ -13,10 +13,11 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   artifactory-node1:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node1
@@ -42,10 +43,11 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   artifactory-node2:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node2
@@ -74,10 +76,11 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -96,7 +99,8 @@ services:
      - ART_BASE_URL=http://artifactory-node1:8081/artifactory
      - SSL=true
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000

--- a/docker-compose/artifactory-ha-shared-data.yml
+++ b/docker-compose/artifactory-ha-shared-data.yml
@@ -14,10 +14,10 @@ services:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   artifactory-node1:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node1
@@ -44,10 +44,10 @@ services:
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   artifactory-node2:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node2
@@ -77,10 +77,10 @@ services:
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -100,7 +100,7 @@ services:
      - SSL=true
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000

--- a/docker-compose/artifactory-ha.yml
+++ b/docker-compose/artifactory-ha.yml
@@ -13,6 +13,11 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   artifactory-node1:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node1
@@ -34,6 +39,11 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   artifactory-node2:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node2
@@ -58,6 +68,11 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -76,3 +91,8 @@ services:
      - ART_BASE_URL=http://artifactory-node1:8081/artifactory
      - SSL=true
     restart: always
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000

--- a/docker-compose/artifactory-ha.yml
+++ b/docker-compose/artifactory-ha.yml
@@ -16,7 +16,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   artifactory-node1:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
@@ -42,7 +42,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   artifactory-node2:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
@@ -71,7 +71,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
@@ -94,5 +94,5 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000

--- a/docker-compose/artifactory-ha.yml
+++ b/docker-compose/artifactory-ha.yml
@@ -14,10 +14,10 @@ services:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   artifactory-node1:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node1
@@ -40,10 +40,10 @@ services:
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   artifactory-node2:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory-node2
@@ -69,10 +69,10 @@ services:
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -92,7 +92,7 @@ services:
      - SSL=true
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000

--- a/docker-compose/artifactory-oss-postgresql.yml
+++ b/docker-compose/artifactory-oss-postgresql.yml
@@ -14,10 +14,10 @@ services:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-oss:5.4.2
     container_name: artifactory
@@ -38,7 +38,7 @@ services:
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000

--- a/docker-compose/artifactory-oss-postgresql.yml
+++ b/docker-compose/artifactory-oss-postgresql.yml
@@ -13,6 +13,10 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-oss:5.4.2
     container_name: artifactory
@@ -32,3 +36,7 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000

--- a/docker-compose/artifactory-oss-postgresql.yml
+++ b/docker-compose/artifactory-oss-postgresql.yml
@@ -16,7 +16,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-oss:5.4.2
@@ -40,5 +40,5 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000

--- a/docker-compose/artifactory-oss-postgresql.yml
+++ b/docker-compose/artifactory-oss-postgresql.yml
@@ -13,10 +13,11 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-oss:5.4.2
     container_name: artifactory
@@ -36,7 +37,8 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000

--- a/docker-compose/artifactory-oss.yml
+++ b/docker-compose/artifactory-oss.yml
@@ -14,5 +14,5 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000

--- a/docker-compose/artifactory-oss.yml
+++ b/docker-compose/artifactory-oss.yml
@@ -11,3 +11,7 @@ services:
 #    environment:
 #     - EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000

--- a/docker-compose/artifactory-oss.yml
+++ b/docker-compose/artifactory-oss.yml
@@ -12,7 +12,7 @@ services:
 #     - EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000

--- a/docker-compose/artifactory-oss.yml
+++ b/docker-compose/artifactory-oss.yml
@@ -11,7 +11,8 @@ services:
 #    environment:
 #     - EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000

--- a/docker-compose/artifactory-pro-nginx-derby.yml
+++ b/docker-compose/artifactory-pro-nginx-derby.yml
@@ -9,10 +9,10 @@ services:
      - /data/artifactory:/var/opt/jfrog/artifactory
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -30,7 +30,7 @@ services:
      - SSL=true
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000

--- a/docker-compose/artifactory-pro-nginx-derby.yml
+++ b/docker-compose/artifactory-pro-nginx-derby.yml
@@ -8,6 +8,10 @@ services:
     volumes:
      - /data/artifactory:/var/opt/jfrog/artifactory
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -24,3 +28,7 @@ services:
      - ART_BASE_URL=http://artifactory:8081/artifactory
      - SSL=true
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000

--- a/docker-compose/artifactory-pro-nginx-derby.yml
+++ b/docker-compose/artifactory-pro-nginx-derby.yml
@@ -8,10 +8,11 @@ services:
     volumes:
      - /data/artifactory:/var/opt/jfrog/artifactory
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -28,7 +29,8 @@ services:
      - ART_BASE_URL=http://artifactory:8081/artifactory
      - SSL=true
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000

--- a/docker-compose/artifactory-pro-nginx-derby.yml
+++ b/docker-compose/artifactory-pro-nginx-derby.yml
@@ -11,7 +11,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
@@ -32,5 +32,5 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000

--- a/docker-compose/artifactory-pro-postgresql.yml
+++ b/docker-compose/artifactory-pro-postgresql.yml
@@ -16,7 +16,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
@@ -40,5 +40,5 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000

--- a/docker-compose/artifactory-pro-postgresql.yml
+++ b/docker-compose/artifactory-pro-postgresql.yml
@@ -14,10 +14,10 @@ services:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory
@@ -38,7 +38,7 @@ services:
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000

--- a/docker-compose/artifactory-pro-postgresql.yml
+++ b/docker-compose/artifactory-pro-postgresql.yml
@@ -13,6 +13,10 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory
@@ -32,3 +36,7 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000

--- a/docker-compose/artifactory-pro-postgresql.yml
+++ b/docker-compose/artifactory-pro-postgresql.yml
@@ -13,10 +13,11 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory
@@ -36,7 +37,8 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000

--- a/docker-compose/artifactory-pro.yml
+++ b/docker-compose/artifactory-pro.yml
@@ -13,6 +13,10 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory
@@ -32,6 +36,10 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -48,3 +56,7 @@ services:
      - ART_BASE_URL=http://artifactory:8081/artifactory
      - SSL=true
     restart: always
+	ulimit:
+		nproc:65535
+			soft:20000
+			hard:40000

--- a/docker-compose/artifactory-pro.yml
+++ b/docker-compose/artifactory-pro.yml
@@ -13,10 +13,11 @@ services:
     volumes:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory
@@ -36,10 +37,11 @@ services:
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -56,7 +58,8 @@ services:
      - ART_BASE_URL=http://artifactory:8081/artifactory
      - SSL=true
     restart: always
-	ulimit:
-		nproc:65535
-			soft:20000
-			hard:40000
+    ulimits:
+        nproc: 65535
+        nofile:
+            soft: 20000
+            hard: 40000

--- a/docker-compose/artifactory-pro.yml
+++ b/docker-compose/artifactory-pro.yml
@@ -16,7 +16,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
@@ -40,7 +40,7 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
@@ -61,5 +61,5 @@ services:
     ulimits:
       nproc: 65535
       nofile:
-        soft: 20000
+        soft: 32000
         hard: 40000

--- a/docker-compose/artifactory-pro.yml
+++ b/docker-compose/artifactory-pro.yml
@@ -14,10 +14,10 @@ services:
      - /data/postgresql:/var/lib/postgresql/data
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.2
     container_name: artifactory
@@ -38,10 +38,10 @@ services:
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.2
     container_name: nginx
@@ -59,7 +59,7 @@ services:
      - SSL=true
     restart: always
     ulimits:
-        nproc: 65535
-        nofile:
-            soft: 20000
-            hard: 40000
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000


### PR DESCRIPTION
The purpose of this PR is to fix an edge case that can occur in strict environments.
It is possible that in some environments, the ulimit inherited from the host OS can be too small for the containers in each compose file to start. This leads to a soft-failure where the compose up starts containers, but they are internally never able to start their application

This was first observed using the current head revision of the repo on 6/26 on Amazon Linux. The Artifactory container reported an error with ulimit for files being too low. Adding the lines included in the PR to the script forced a ulimit and solved the startup issue.