### PR TITLE
Pro Swarm sample: Fixing to run in current Swarm

### DIFF
--- a/swarm/artifactory-pro.yml
+++ b/swarm/artifactory-pro.yml
@@ -1,8 +1,9 @@
 version: '3'
+
 services:
+
   postgresql:
     image: docker.bintray.io/postgres:9.5.2
-    container_name: postgresql
     ports:
      - 5432:5432
     environment:
@@ -10,15 +11,20 @@ services:
      # The following must match the DB_USER and DB_PASSWORD values passed to Artifactory
      - POSTGRES_USER=artifactory
      - POSTGRES_PASSWORD=password
-    volumes:
-     - /data/postgresql:/var/lib/postgresql/data
-    restart: always
+    #volumes:
+    # - artifactory:/var/lib/postgresql/data
     deploy:
       mode: replicated
       replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints: [node.role != manager]
+
   artifactory:
     image: docker.bintray.io/jfrog/artifactory-pro:5.4.4
-    container_name: artifactory
     ports:
      - 8081:8081
     depends_on:
@@ -26,10 +32,14 @@ services:
     deploy:
       mode: replicated
       replicas: 1
-    links:
-     - postgresql
-    volumes:
-     - /data/artifactory:/var/opt/jfrog/artifactory
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints: [node.role != manager]
+    #volumes:
+    # - artifactory:/var/opt/jfrog/artifactory
     environment:
      - DB_TYPE=postgresql
      # The following must match the POSTGRES_USER and POSTGRES_PASSWORD values passed to PostgreSQL
@@ -37,10 +47,9 @@ services:
      - DB_PASSWORD=password
      # Add extra Java options by uncommenting the following line
      #- EXTRA_JAVA_OPTIONS=-Xmx4g
-    restart: always
+
   nginx:
     image: docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.4
-    container_name: nginx
     ports:
      - 80:80
      - 443:443
@@ -49,11 +58,17 @@ services:
     deploy:
       mode: replicated
       replicas: 1
-    links:
-     - artifactory
-    volumes:
-     - /data/nginx:/var/opt/jfrog/nginx
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+      placement:
+        constraints: [node.role != manager]
+    #volumes:
+    # - artifactory:/var/opt/jfrog/nginx
     environment:
      - ART_BASE_URL=http://artifactory:8081/artifactory
      - SSL=true
-    restart: always
+
+#volumes:
+#  artifactory:


### PR DESCRIPTION
Problem
-----

* Current file does not work to deploy in a swarm from newer docker engines
 * Apparently `artifactory-pro.yml` is suitable for `docker-compose.yml`?

```
[ec2-user@ip-xx-xx-48-169 ~]$ docker --version
Docker version 17.05.0-ce-rc3, build 90d35ab
```

* Current behavior does not start because it can't mount the volumes defined

```

$ docker stack deploy -c artifactory-pro.yml  artfctry

[ec2-user@ip-xxx-xxx-48-169 ~]$ docker stack ps artfctry
ID                  NAME                         IMAGE                                                 NODE                           DESIRED STATE       CURRENT STATE              ERROR                              PORTS
nsjdv1oe6u4k        artfctry_postgresql.1        docker.bintray.io/postgres:9.5.2                      ip-xxx-yyy-48-74.vpc.internal    Ready               Rejected 2 seconds ago     "invalid mount config for type…"
rw657kva6fe5        artfctry_artifactory.1       docker.bintray.io/jfrog/artifactory-pro:5.4.4         ip-xxx-yyy-49-98.vpc.internal    Ready               Rejected 1 second ago      "invalid mount config for type…"
tt3g7jd5gweu        artfctry_postgresql.1        docker.bintray.io/postgres:9.5.2                      ip-xxx-yyy-49-13.vpc.internal    Shutdown            Rejected 5 seconds ago     "invalid mount config for type…"
jn1qw6sei5qz        artfctry_artifactory.1       docker.bintray.io/jfrog/artifactory-pro:5.4.4         ip-xxx-yyy-48-74.vpc.internal    Shutdown            Rejected 7 seconds ago     "invalid mount config for type…"
mlkll53otrcm        artfctry_postgresql.1        docker.bintray.io/postgres:9.5.2                      ip-xxx-yyy-49-44.vpc.internal    Shutdown            Rejected 10 seconds ago    "invalid mount config for type…"
f1ht10vb8shx        artfctry_artifactory.1       docker.bintray.io/jfrog/artifactory-pro:5.4.4         ip-xxx-yyy-48-240.vpc.internal   Shutdown            Rejected 10 seconds ago    "invalid mount config for type…"
5y2rad3iyxak        artfctry_postgresql.1        docker.bintray.io/postgres:9.5.2                      ip-xxx-yyy-49-13.vpc.internal    Shutdown            Rejected 15 seconds ago    "invalid mount config for type…"
be4bt0n9b8og        artfctry_artifactory.1       docker.bintray.io/jfrog/artifactory-pro:5.4.4         ip-xxx-yyy-48-74.vpc.internal    Shutdown            Rejected 17 seconds ago    "invalid mount config for type…"
mhwrq43ylj5f         \_ artfctry_artifactory.1   docker.bintray.io/jfrog/artifactory-pro:5.4.4         ip-xxx-yyy-49-92.vpc.internal    Shutdown            Rejected 21 seconds ago    "invalid mount config for type…"
thn750n4gdds        artfctry_nginx.1             docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.4   ip-xxx-yyy-48-94.vpc.internal    Running             Preparing 24 seconds ago
v9784uqsa7bo        artfctry_postgresql.1        docker.bintray.io/postgres:9.5.2                      ip-xxx-yyy-48-169.vpc.internal   Shutdown            Rejected 21 seconds ago    "invalid mount config for type…"
n6pdw0kk5cqk        artfctry_nginx.1             docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.4   ip-xxx-yyy-48-145.vpc.internal   Shutdown            Rejected 23 seconds ago    "invalid mount config for type…"
```

Solution
-----

* Replacing the volumes definition to a named one
* Adding the restart policy with a delay
* Adding a placement to be NOT the swarm manager nodes (by default docker documentation)
* Defining the named volume, without the driver

The result with this patch is a runnable installation in a Swarm that can be used to start developing.. What needs to be done:

* Network Placement 
* Persistent Volumes
* Logging

Users can define on their own. 

```
$ docker stack deploy -c artifactory-pro.yml  artfctry
Creating service artfctry_postgresql
Creating service artfctry_artifactory
Creating service artfctry_nginx

[ec2-user@ip-xxx-yyy-48-169 ~]$ docker stack ps artfctry
ID                  NAME                     IMAGE                                                 NODE                          DESIRED STATE       CURRENT STATE            ERROR               PORTS
sgduqota3zrc        artfctry_nginx.1         docker.bintray.io/jfrog/nginx-artifactory-pro:5.4.4   ip-xxx-yyy-49-44.vpc.internal   Running             Running 14 seconds ago
ozs46nbql2j7        artfctry_artifactory.1   docker.bintray.io/jfrog/artifactory-pro:5.4.4         ip-xxx-yyy-48-94.vpc.internal   Running             Running 16 seconds ago
wm7meyvhyyi2        artfctry_postgresql.1    docker.bintray.io/postgres:9.5.2                      ip-xxx-yyy-48-74.vpc.internal   Running             Running 18 seconds ago
```

Could get the app running in EC2 ELB....

<img width="1421" alt="for-pr" src="https://user-images.githubusercontent.com/131457/28964268-e78793d0-78c0-11e7-9668-ce16c41a4fbd.png">