### PR TITLE
Switch from grabbing the ip address to hostname.

### DIFF
--- a/kubernetes/helm/artifactory/templates/NOTES.txt
+++ b/kubernetes/helm/artifactory/templates/NOTES.txt
@@ -11,7 +11,7 @@ Congratulations. You have just deployed JFrog Artifactory Pro!
 
    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
          You can watch the status of the service by running 'kubectl get svc -w {{ template "nginx.name" . }}'
-   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nginx.name" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nginx.name" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
    echo http://$SERVICE_IP/
 
    {{- else if contains "ClusterIP" .Values.nginx.service.type }}


### PR DESCRIPTION
Since the chart is creating a load balancer the `ip` address may change or not be defined.  The hostname should always be available.

On the kubernetes cluster I was running on, `ip` was always blank.