### PR TITLE
Source ranges & SSL Certificate

### DIFF
--- a/kubernetes/helm/artifactory/README.md
+++ b/kubernetes/helm/artifactory/README.md
@@ -93,6 +93,7 @@ The following tables lists the configurable parameters of the artifactory chart 
 | `nginx.image.pullPolicy`    | Container pull policy                   | `IfNotPresent`                |
 | `nginx.image.version`       | Container image tag               | `5.4.6`                                                  |
 | `nginx.service.type`| Nginx service type | `LoadBalancer` |
+| `nginx.service.sourceRanges` | Nginx source ranges for `LoadBalancer` | |
 | `nginx.externalPortHttp` | Nginx service external port | `80`   |
 | `nginx.internalPortHttp` | Nginx service internal port | `80`   |
 | `nginx.externalPortHttps` | Nginx service external port | `443`   |

--- a/kubernetes/helm/artifactory/README.md
+++ b/kubernetes/helm/artifactory/README.md
@@ -92,6 +92,7 @@ The following tables lists the configurable parameters of the artifactory chart 
 | `nginx.image.repository`    | Container image                   | `docker.bintray.io/jfrog/nginx-artifactory-pro`                |
 | `nginx.image.pullPolicy`    | Container pull policy                   | `IfNotPresent`                |
 | `nginx.image.version`       | Container image tag               | `5.4.6`                                                  |
+| `nginx.service.sourceRanges` | The SSL certificate ARN to use for the load balancer TLS | |
 | `nginx.service.type`| Nginx service type | `LoadBalancer` |
 | `nginx.service.sourceRanges` | Nginx source ranges for `LoadBalancer` | |
 | `nginx.externalPortHttp` | Nginx service external port | `80`   |

--- a/kubernetes/helm/artifactory/templates/nginx-service.yaml
+++ b/kubernetes/helm/artifactory/templates/nginx-service.yaml
@@ -8,6 +8,11 @@ metadata:
     component: "{{ .Values.nginx.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    {{- if .Values.nginx.service.certificateArn }}
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.nginx.service.certificateArn }}
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
+    {{- end }}
 spec:
   type: {{ .Values.nginx.service.type }}
   ports:

--- a/kubernetes/helm/artifactory/templates/nginx-service.yaml
+++ b/kubernetes/helm/artifactory/templates/nginx-service.yaml
@@ -23,3 +23,9 @@ spec:
     app: {{ template "name" . }}
     component: "{{ .Values.nginx.name }}"
     release: {{ .Release.Name }}
+  {{- if .Values.nginx.service.sourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.nginx.service.sourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}

--- a/kubernetes/helm/artifactory/values.yaml
+++ b/kubernetes/helm/artifactory/values.yaml
@@ -60,6 +60,7 @@ nginx:
   service:
     ## For minikube, set this to NodePort, elsewhere use LoadBalancer
     type: LoadBalancer
+    sourceRanges:
   externalPortHttp: 80
   internalPortHttp: 80
   externalPortHttps: 443

--- a/kubernetes/helm/artifactory/values.yaml
+++ b/kubernetes/helm/artifactory/values.yaml
@@ -61,6 +61,7 @@ nginx:
     ## For minikube, set this to NodePort, elsewhere use LoadBalancer
     type: LoadBalancer
     sourceRanges:
+    certificateArn:
   externalPortHttp: 80
   internalPortHttp: 80
   externalPortHttps: 443


### PR DESCRIPTION
Allow for helm users to specify source IP ranges and SSL Certificates to lock down Artifactory connections.