### PR TITLE
Added features that allow for more control on internal and external services

### DIFF
--- a/kubernetes/helm/artifactory/README.md
+++ b/kubernetes/helm/artifactory/README.md
@@ -88,6 +88,7 @@ The following tables lists the configurable parameters of the artifactory chart 
 | `artifactory.persistence.accessMode` | Artifactory persistence volume access mode | `ReadWriteOnce`   |
 | `artifactory.persistence.size` | Artifactory persistence volume size | `20Gi`   |
 | `nginx.name` | Nginx name | `nginx`   |
+| `nginx.anotations` | Annotations to add to the nginx service | |
 | `nginx.replicaCount` | Nginx replica count | `1`   |
 | `nginx.image.repository`    | Container image                   | `docker.bintray.io/jfrog/nginx-artifactory-pro`                |
 | `nginx.image.pullPolicy`    | Container pull policy                   | `IfNotPresent`                |
@@ -103,6 +104,9 @@ The following tables lists the configurable parameters of the artifactory chart 
 | `nginx.persistence.enabled` | Nginx persistence volume enabled | `true`   |
 | `nginx.persistence.accessMode` | Nginx persistence volume access mode | `ReadWriteOnce`   |
 | `nginx.persistence.size` | Nginx persistence volume size | `5Gi`   |
+| `nginx.service.sourceRanges` | Nginx source ranges for `LoadBalancer` | |
+| `serviceInternal.enable` | Wether to enable a second internal service for access inside kubernetes | `false` |
+| `serviceInternal.anotations` | Annotations for the internal service | |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/kubernetes/helm/artifactory/templates/nginx-service-internal.yaml
+++ b/kubernetes/helm/artifactory/templates/nginx-service-internal.yaml
@@ -1,16 +1,17 @@
+{{- if .Values.serviceInternal.enable }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "nginx.name" . }}
+  name: {{ template "nginx.name" . }}-internal
   labels:
     app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nginx.name }}"
+    component: "{{ .Values.nginx.name }}-internal"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  {{- if .Values.nginx.service.annotations }}
+  {{- if .Values.serviceInternal.annotations }}
   annotations:
-{{ toYaml .Values.nginx.service.annotations | indent 4 }}
+{{ toYaml .Values.serviceInternal.annotations | indent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.nginx.service.type }}
@@ -27,9 +28,4 @@ spec:
     app: {{ template "name" . }}
     component: "{{ .Values.nginx.name }}"
     release: {{ .Release.Name }}
-  {{- if .Values.nginx.service.sourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range .Values.nginx.service.sourceRanges }}
-  - {{ . }}
-  {{- end }}
-  {{- end }}
+{{- end }}

--- a/kubernetes/helm/artifactory/values.yaml
+++ b/kubernetes/helm/artifactory/values.yaml
@@ -60,6 +60,9 @@ nginx:
   service:
     ## For minikube, set this to NodePort, elsewhere use LoadBalancer
     type: LoadBalancer
+    # Master Service annotations
+    annotations:
+    sourceRanges:
   externalPortHttp: 80
   internalPortHttp: 80
   externalPortHttps: 443
@@ -72,3 +75,8 @@ nginx:
     enabled: true
     accessMode: ReadWriteOnce
     size: 5Gi
+
+# Service for accessing artifactory inside kubernetes
+serviceInternal:
+  enabled: false
+  annotations:


### PR DESCRIPTION
 - Added the ability to add annotations to internal and external services.  This allows Kubernetes to
   do things like update DNS records and assign SSL certificates.
 - Added internal service that is disabled by default.  This allows for Kubernetes to set up an
   internal service that shares the same DNS and certificates when accessed inside of the cluster.
 - Added the ability to specify source CIDR to the external service to restrict access.